### PR TITLE
Just use go get for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ go:
 go_import_path: github.com/specialedge/hangar-api
 
 install:
-  - go get github.com/gorilla/mux
-  - go get github.com/cavaliercoder/grab
-  - go get github.com/sirupsen/logrus
+  - go get
   - go get github.com/golang/lint/golint 
-  - go get github.com/common-nighthawk/go-figure                       
 
 script:
  - go test -v ./...    


### PR DESCRIPTION
Cleans up the .travis.yml a bit to just use `go get` as well as a get for golint rather than an ever expanding list of dependencies, has the advantage that this is likely to be the way any user fetches the code so more representative test.

Suggest this may be the point we need to discuss a strategy on vendoring/using go dep for dependency pinning.